### PR TITLE
Revert "tasks/configure.yml: Validate systemd unit files"

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,7 +15,6 @@
   template:
     src: '{{ item.src }}'
     dest: '{{ item.dest }}'
-    validate: systemd-analyze verify %s
   notify: "Restart pretix serivces"
   with_items:
     - {src: "pretix_web.service.j2",dest: "/lib/systemd/system/pretix_web.service"}


### PR DESCRIPTION
Reverts stuvusIT/pretix#2
Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232